### PR TITLE
Add ide team to recipe-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,3 +56,11 @@ extra:
     - Aditi2424
     - akrishna1995
     - bhadrip
+    - aws-jasakshi
+    - aws-prayags
+    - sgganjo
+    - aws-jeffrey-yang
+    - henrywa2
+    - aws-pavankks
+    - aakashmandavilli96
+


### PR DESCRIPTION
Adding ide team members as a maintainer for the sagemaker-studio-analytics-extension package